### PR TITLE
fix: openURL parame

### DIFF
--- a/src/web/src/app/modules/details/app-detail.component.html
+++ b/src/web/src/app/modules/details/app-detail.component.html
@@ -72,7 +72,7 @@
 
         <ng-container *ngIf="app.info.homePage">
           <div i18n>Website:</div>
-          <div class="webSite" (click)="openURL(app.homePage)">
+          <div class="webSite" (click)="openURL(app.info.homePage)">
             {{ app.info.homePage }}
           </div>
         </ng-container>


### PR DESCRIPTION
fixed `openURL` on click homepage
https://github.com/linuxdeepin/internal-discussion/issues/1980